### PR TITLE
fix: Revert changes to events section

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,11 @@
         }
         .slide {
             display: none;
-            transition: opacity 0.5s ease-in-out;
+            animation: fade 1.5s;
+        }
+        @keyframes fade {
+            from {opacity: .4}
+            to {opacity: 1}
         }
         .prev, .next {
             cursor: pointer;
@@ -243,7 +247,7 @@
                 <div class="container mx-auto px-6 text-center text-white">
                     <h1 class="text-5xl md:text-8xl font-extrabold leading-tight mb-4">Un Lugar Para Pertenecer</h1>
                     <p class="text-lg md:text-xl text-gray-300 mb-6 max-w-3xl mx-auto">Somos una iglesia Cristiana, una familia multicultural creciendo en fe, esperanza y amor en el corazón de Bridgeport.</p>
-                    <p class="text-amber-300 italic text-xl mb-8 font-serif">"Porque donde están dos o tres congregados en mi nombre, allí estoy yo en medio de ellos." - Mateo 18:20</p>
+                    <p class="text-amber-300 italic text-xl mb-8 font-serif">"Y todos los días, en el templo y por las casas, no cesaban de enseñar y predicar a Jesucristo." - Hechos 5:42</p>
                     <div class="space-y-4 md:space-y-0 md:space-x-4">
                         <a href="#new" class="btn btn-primary">Planifica Tu Visita</a>
                     </div>
@@ -306,9 +310,17 @@
                         <img src="https://i.ibb.co/yQWkS0R/1000061421.jpg" alt="Pastores Luis y Ana Mateo" class="rounded-2xl shadow-lg w-full">
                     </div>
                     <div class="md:w-1/2">
-                        <h3 class="text-4xl font-bold text-white mb-4 font-serif">Guiados por Nuestros Pastores</h3>
-                        <p class="text-gray-300 mb-6 text-lg">Bajo el liderazgo de los pastores <strong>Luis y Ana Mateo</strong>, Visión Celestial es una iglesia comprometida con las verdades eternas de la Biblia. Somos una iglesia multicultural que celebra la diversidad de las naciones, unidos como un solo cuerpo en Cristo. Creemos en el poder transformador del Evangelio y nos esforzamos por vivir nuestra fe de manera auténtica y significativa. Nuestra comunidad es un lugar para preguntas, crecimiento y para descubrir juntos el profundo amor de Jesucristo.</p>
-                        <a href="#" class="btn btn-primary">Nuestras Creencias</a>
+                        <h3 class="text-4xl font-bold text-white mb-4 font-serif">Nuestra Misión</h3>
+                        <p class="text-gray-300 mb-4 text-lg">Somos una Iglesia Multicultural. Nuestra visión es la predicación del Evangelio de Jesucristo, local y internacional a toda criatura por cuanto es un mensaje vigente y poderoso para transformar al hombre y a la mujer de hoy.</p>
+                        <p class="text-gray-300 mb-4 text-lg">Ganar almas por el Espíritu Santo en santidad, consagración y servicio. Levantar una generación de discípulos y líderes que ganen las naciones de la tierra. Establecer ministerios fieles e integrales conforme al propósito y voluntad de Dios para con la iglesia.</p>
+                        <h4 class="text-2xl font-bold text-white mb-2 mt-6 font-serif">Comprometidos con:</h4>
+                        <ul class="list-disc list-inside text-gray-300 space-y-2 text-lg">
+                            <li>Evangelización.</li>
+                            <li>Discipulado.</li>
+                            <li>Formación de líderes.</li>
+                            <li>Misiones.</li>
+                        </ul>
+                        <p class="text-gray-300 mt-4 text-lg">Con el sostenimiento, desarrollo y avance de la Obra de la iglesia y el Evangelio en toda el área de Connecticut.</p>
                     </div>
                 </div>
             </div>
@@ -321,21 +333,21 @@
                 <p class="section-subtitle">El crecimiento espiritual ocurre en comunidad. Encuentra tu lugar para conectar, servir y crecer con otros en Visión Celestial.</p>
                 <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <!-- Ministry Card 1 -->
-                    <div class="ministry-card group" style="background-image: url('https://i.postimg.cc/hDVzKL9L/IMG-3707.jpg');">
+                    <div class="ministry-card group" style="background-image: url('https://images.unsplash.com/photo-1459749411175-04bf5292ceea?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80');">
                         <div class="ministry-content flex flex-col justify-end h-64">
                             <h3 class="text-2xl font-bold mb-2 font-serif">En Espíritu y en Verdad</h3>
                             <p class="text-gray-200 mb-4 opacity-0 group-hover:opacity-100 transition-opacity duration-500">Nuestro ministerio de alabanza, dedicado a guiar a la congregación a una adoración genuina.</p>
                         </div>
                     </div>
                     <!-- Ministry Card 2: User-provided image updated here -->
-                    <div class="ministry-card" style="background-image: url('https://i.ibb.co/9v0p4pY/1000049383.jpg');">
+                    <div class="ministry-card" style="background-image: url('https://i.postimg.cc/kqYgWR4x/IMG-3588.jpg');">
                         <div class="ministry-content flex flex-col justify-end h-64">
                             <h3 class="text-2xl font-bold mb-2 font-serif">Visión Celestial Danza y Arte</h3>
                             <p class="text-gray-200 mb-4">Adoramos a Dios a través del movimiento y la creatividad. Un ministerio para expresar nuestra fe con el cuerpo y el alma.</p>
                         </div>
                     </div>
                     <!-- Ministry Card 3 -->
-                    <div class="ministry-card" style="background-image: url('https://images.unsplash.com/photo-1521587760476-6c12a4b040da?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80');">
+                    <div class="ministry-card" style="background-image: url('https://i.postimg.cc/B4F1ZCNj/Gemini-Generated-Image-bwffepbwffepbwff.png');">
                         <div class="ministry-content flex flex-col justify-end h-64">
                             <h3 class="text-2xl font-bold mb-2 font-serif">La Tribu de Judá</h3>
                             <p class="text-gray-200 mb-4">Nuestra escuela dominical, donde los niños y jóvenes aprenden la Palabra de Dios de una manera divertida.</p>
@@ -376,35 +388,38 @@
                 <h2 class="section-title">Próximos Eventos</h2>
                 <p class="section-subtitle">¡No te pierdas lo que está sucediendo en Visión Celestial! Únete a nosotros para estos tiempos especiales de adoración y compañerismo.</p>
                 
-                <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    <!-- Event 1: Domingo de Avivamiento -->
+                <div class="grid lg:grid-cols-3 gap-8">
+                    <!-- Event 1 -->
                     <div class="glass-effect rounded-2xl shadow-2xl overflow-hidden flex flex-col event-card">
-                        <div id="slideshow-avivamiento" class="relative slideshow-container h-48">
-                            <div class="slide" style="display: block;">
-                                <img src="https://i.postimg.cc/9cxNBTwY/Gemini-Generated-Image-5gjhcy5gjhcy5gjh.png" alt="Domingo de avivamiento 1" class="w-full h-full object-cover">
-                            </div>
-                            <div class="slide">
-                                <img src="https://i.postimg.cc/4sRCKzpK/Gemini-Generated-Image-n2aqqtn2aqqtn2aq.png" alt="Domingo de avivamiento 2" class="w-full h-full object-cover">
-                            </div>
-                        </div>
+                        <img src="https://i.ibb.co/yQWkS0R/1000061421.jpg" alt="Noche de Adoración" class="w-full h-48 object-cover">
                         <div class="p-6 flex flex-col flex-grow">
-                            <h3 class="text-2xl font-bold font-serif text-white mb-2">Domingo de Avivamiento</h3>
-                            <p class="text-amber-300 mb-4 flex-grow">Cada Domingo a las 10:00 AM</p>
+                            <h3 class="text-2xl font-bold font-serif text-white mb-2">Noche de Adoración</h3>
+                            <p class="text-amber-300 mb-4 flex-grow">Viernes, 29 de Agosto | 8:00 PM</p>
+                            <a href="https://www.facebook.com/share/16bAo1vvSS/" target="_blank" rel="noopener noreferrer" class="btn btn-primary mt-auto text-center">Más Detalles</a>
                         </div>
                     </div>
-                    <!-- More events can be added here -->
+                    <!-- Event 2 -->
+                    <div class="glass-effect rounded-2xl shadow-2xl overflow-hidden flex flex-col event-card">
+                        <img src="https://images.unsplash.com/photo-1543269865-cbf427effbad?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80" alt="Servicio Familiar" class="w-full h-48 object-cover">
+                        <div class="p-6 flex flex-col flex-grow">
+                            <h3 class="text-2xl font-bold font-serif text-white mb-2">Servicio Especial Familiar</h3>
+                            <p class="text-amber-300 mb-4 flex-grow">Domingo, 7 de Septiembre | 10:00 AM</p>
+                            <a href="#" class="btn btn-primary mt-auto text-center">Más Detalles</a>
+                        </div>
+                    </div>
+                    <!-- Event 3 -->
+                    <div class="glass-effect rounded-2xl shadow-2xl overflow-hidden flex flex-col event-card">
+                        <img src="https://images.unsplash.com/photo-1587825140708-dfaf72ae4b04?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80" alt="Conferencia" class="w-full h-48 object-cover">
+                        <div class="p-6 flex flex-col flex-grow">
+                            <h3 class="text-2xl font-bold font-serif text-white mb-2">Conferencia de Matrimonios</h3>
+                            <p class="text-amber-300 mb-4 flex-grow">Sábado, 20 de Septiembre | 9:00 AM - 2:00 PM</p>
+                            <a href="#" class="btn btn-primary mt-auto text-center">Regístrate Aquí</a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>
 
-        <!-- Giving & Stewardship -->
-        <section id="giving" class="py-20 bg-black text-white" style="background-image: linear-gradient(rgba(10, 25, 49, 0.9), rgba(10, 25, 49, 0.9)), url('https://images.unsplash.com/photo-1593113598332-cd288d649433?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1170&q=80'); background-size: cover; background-position: center; background-attachment: fixed;">
-            <div class="container mx-auto px-6 text-center reveal">
-                <h2 class="section-title">Colabora con la Misión</h2>
-                <p class="section-subtitle">Tu generosidad es un acto de adoración que impulsa el ministerio de Visión Celestial, permitiéndonos compartir la esperanza del Evangelio en Bridgeport y más allá.</p>
-                <a href="#" class="btn btn-primary">Ofrendar en Línea</a>
-            </div>
-        </section>
         
         <!-- I'm New Section -->
         <section id="new" class="py-20" style="background-color: #0F2C59;">
@@ -533,28 +548,8 @@
         window.addEventListener('scroll', revealOnScroll);
         revealOnScroll(); // Trigger on load
 
-        // Slideshow Logic for events
-        document.addEventListener('DOMContentLoaded', () => {
-            const slideshows = document.querySelectorAll('.slideshow-container');
+        // Slideshow Logic is no longer needed.
 
-            slideshows.forEach(slideshow => {
-                let slideIndex = 0;
-                const slides = slideshow.querySelectorAll('.slide');
-
-                function showSlides() {
-                    slides.forEach(slide => {
-                        slide.style.opacity = '0';
-                        slide.style.position = 'absolute';
-                    });
-                    slideIndex++;
-                    if (slideIndex > slides.length) { slideIndex = 1; }
-                    slides[slideIndex - 1].style.opacity = '1';
-                }
-
-                showSlides();
-                setInterval(showSlides, 4000); // Change image every 4 seconds
-            });
-        });
     </script>
 
     <!-- Prayer Wall Logic -->


### PR DESCRIPTION
This reverts the recent redesign of the "Próximos Eventos" section, as it was causing issues on the page.

The following changes from the previous commit have been undone:
- Redesign of the events section grid.
- Implementation of slideshow functionality.
- Update to the "En Espíritu y en Verdad" ministry card image.

The codebase is now restored to the state prior to these changes, which includes the updated bible verse, the correct ministry images, the removed "Ofrenda" section, and the new mission statement.